### PR TITLE
Improve documentation for easier setup of toolchain

### DIFF
--- a/Readme.adoc
+++ b/Readme.adoc
@@ -6,7 +6,8 @@ Run rust projects on the WHY2025 Badge. Just fork this repository and start codi
 
 To build the project just run `cargo build --release`.
 
-You need to have a rust toolchain for `riscv32imafc-unknown-none-elf` installed. If you are using nix, you can run `nix develop .` to get everything set up.
+You need to have a nightly rust toolchain for `riscv32imafc-unknown-none-elf` installed. If you are using nix, you can run `nix develop .` to get everything set up.
+For example run: `rustup toolchain install nightly  -t riscv32imafc-unknown-none-elf`
 
 == Running
 


### PR DESCRIPTION
Improved the life of fellow hackers by both being more specific with the required toolchain (stable doesn't work!), and giving direct example because rustup install is not very straightforward for the common hacker.